### PR TITLE
Update watchtower schedules and clean up domain references

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ docker compose logs -f [service-name]
 ### Core Services
 - **Open-WebUI**: AI chat interface at `https://webui.yourdomain.com`
 - **Perplexica**: AI-powered search at `https://perplexica.yourdomain.com`
-- **Authelia**: Authentication portal at `https://auth-m4.yourdomain.com`
+- **Authelia**: Authentication portal at `https://auth.yourdomain.com`
 - **Nginx**: Reverse proxy with SSL termination
 
 ### Architecture
@@ -62,9 +62,11 @@ Access at `http://localhost:8081`
 ## SSL Certificates
 
 Place certificates in `services/nginx/ssl/`:
-- `webui-m4.yourdomain.com.crt` + `.key`
-- `perplexica-m4.yourdomain.com.crt` + `.key`
-- `auth-m4.yourdomain.com.crt` + `.key`
+- `webui.yourdomain.com.crt` + `.key`
+- `perplexica.yourdomain.com.crt` + `.key`
+- `auth.yourdomain.com.crt` + `.key`
+
+**Note**: Simplified domain names are used for local networks (no machine ID suffix).
 
 Generate self-signed certificates:
 ```bash

--- a/services/monitoring/docker-compose.yml
+++ b/services/monitoring/docker-compose.yml
@@ -1,42 +1,10 @@
 # Monitoring Services - Separate Watchtowers for Service and Canary
 
 services:
-  # Main service watchtower - weekly updates for stability
+  # Main service watchtower - daily updates for stability
   watchtower-service:
     image: containrrr/watchtower
     container_name: ${USER_PREFIX}-ow-watchtower-service
-    restart: unless-stopped
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    environment:
-      - TZ=UTC
-      - WATCHTOWER_CLEANUP=true
-      - WATCHTOWER_INCLUDE_STOPPED=false
-      - WATCHTOWER_INCLUDE_RESTARTING=true
-      - WATCHTOWER_POLL_INTERVAL=604800  # Check weekly (7 days)
-      - WATCHTOWER_MONITOR_ONLY=false
-      - WATCHTOWER_NOTIFICATIONS_LEVEL=info
-      - WATCHTOWER_REMOVE_VOLUMES=false  # Never remove volumes
-      - WATCHTOWER_SCOPE=service
-    networks:
-      - app-network
-    labels:
-      - "com.carian-observatory.watchtower.scope=service"
-      - "com.carian-observatory.watchtower.schedule=weekly"
-    # Monitor main production services
-    command: >
-      --scope service
-      ${USER_PREFIX}-open-webui-service
-      ${USER_PREFIX}-perplexica-service
-      ${USER_PREFIX}-perplexica-searxng
-      ${USER_PREFIX}-authelia-service
-      ${USER_PREFIX}-authelia-redis
-      ${USER_PREFIX}-nginx-service
-
-  # Canary watchtower - daily updates for testing latest versions
-  watchtower-canary:
-    image: containrrr/watchtower
-    container_name: ${USER_PREFIX}-ow-watchtower-canary
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -49,12 +17,44 @@ services:
       - WATCHTOWER_MONITOR_ONLY=false
       - WATCHTOWER_NOTIFICATIONS_LEVEL=info
       - WATCHTOWER_REMOVE_VOLUMES=false  # Never remove volumes
+      - WATCHTOWER_SCOPE=service
+    networks:
+      - app-network
+    labels:
+      - "com.carian-observatory.watchtower.scope=service"
+      - "com.carian-observatory.watchtower.schedule=daily"
+    # Monitor main production services
+    command: >
+      --scope service
+      ${USER_PREFIX}-open-webui-service
+      ${USER_PREFIX}-perplexica-service
+      ${USER_PREFIX}-perplexica-searxng
+      ${USER_PREFIX}-authelia-service
+      ${USER_PREFIX}-authelia-redis
+      ${USER_PREFIX}-nginx-service
+
+  # Canary watchtower - hourly updates for testing latest versions
+  watchtower-canary:
+    image: containrrr/watchtower
+    container_name: ${USER_PREFIX}-ow-watchtower-canary
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - TZ=UTC
+      - WATCHTOWER_CLEANUP=true
+      - WATCHTOWER_INCLUDE_STOPPED=false
+      - WATCHTOWER_INCLUDE_RESTARTING=true
+      - WATCHTOWER_POLL_INTERVAL=3600    # Check hourly (1 hour)
+      - WATCHTOWER_MONITOR_ONLY=false
+      - WATCHTOWER_NOTIFICATIONS_LEVEL=info
+      - WATCHTOWER_REMOVE_VOLUMES=false  # Never remove volumes
       - WATCHTOWER_SCOPE=canary
     networks:
       - app-network
     labels:
       - "com.carian-observatory.watchtower.scope=canary"
-      - "com.carian-observatory.watchtower.schedule=daily"
+      - "com.carian-observatory.watchtower.schedule=hourly"
     # Monitor canary services only
     command: >
       --scope canary


### PR DESCRIPTION
This PR updates the watchtower update schedules to provide better deployment cadence and cleans up domain references in documentation.

## Background

The current watchtower setup had production services updating weekly, which was too conservative, and canary services updating daily, which wasn't aggressive enough for early testing. Also found some domain-specific references in documentation that needed to be generalized.

## Changes

**Watchtower Schedule Updates:**
- Production services: Weekly → Daily (24 hours)  
- Canary services: Daily → Hourly (1 hour)

This gives us daily stable updates for production while canary aggressively tests the latest versions hourly.

**Documentation Cleanup:**
- Updated README.md to use generic domain examples
- Simplified domain structure documentation (removed machine ID suffixes)
- Cleaned up documentation references

## Testing

Verified both watchtower services restart correctly with new schedules:
- Production watchtower: Next check in ~24 hours
- Canary watchtower: Next check in ~1 hour

Container logs confirm the new timing is active.