### PR TITLE
fix: resolve iframe issues and clean up dashboard services

### DIFF
--- a/services/nginx/docker-compose.yml
+++ b/services/nginx/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - GLANCE_DOMAIN=${GLANCE_DOMAIN}
       - GENERIC_GLANCE_DOMAIN=${GENERIC_GLANCE_DOMAIN}
     volumes:
-      - ./configs/https.conf.template:/etc/nginx/templates/default.conf.template:ro
+      - ./configs/https.conf:/etc/nginx/conf.d/default.conf:ro
       - ./ssl:/etc/ssl/custom:ro
     depends_on:
       - open-webui

--- a/templates/services/nginx/configs/https.conf.template
+++ b/templates/services/nginx/configs/https.conf.template
@@ -157,7 +157,7 @@ server {
         proxy_hide_header X-Frame-Options;
         proxy_hide_header Content-Security-Policy;
         add_header X-Frame-Options "ALLOWFROM https://${GLANCE_DOMAIN}" always;
-        add_header Content-Security-Policy "frame-ancestors 'self' https://${GLANCE_DOMAIN} https://*.corporateseas.com;" always;
+        add_header Content-Security-Policy "frame-ancestors 'self' https://${GLANCE_DOMAIN} https://*.${PRIMARY_DOMAIN};" always;
 
         proxy_set_header Remote-User $user;
         proxy_pass http://perplexica:3000/;

--- a/templates/services/nginx/configs/https.conf.template
+++ b/templates/services/nginx/configs/https.conf.template
@@ -146,6 +146,107 @@ server {
         proxy_buffering off;
         proxy_request_buffering off;
     }
+
+    # Iframe-friendly route for Perplexica
+    location /iframe {
+        auth_request /authelia;
+        auth_request_set $user $upstream_http_remote_user;
+        error_page 401 =302 https://${AUTH_DOMAIN}/?rd=$scheme://$http_host$request_uri;
+
+        # Remove restrictive frame options and CSP for iframe embedding
+        proxy_hide_header X-Frame-Options;
+        proxy_hide_header Content-Security-Policy;
+        add_header X-Frame-Options "ALLOWFROM https://${GLANCE_DOMAIN}" always;
+        add_header Content-Security-Policy "frame-ancestors 'self' https://${GLANCE_DOMAIN} https://*.corporateseas.com;" always;
+
+        proxy_set_header Remote-User $user;
+        proxy_pass http://perplexica:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+
+        # Important: Add headers to help with iframe compatibility
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Server $host;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_connect_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+        proxy_buffering off;
+        proxy_request_buffering off;
+
+        # Enable sub_filter to inject localStorage workaround
+        sub_filter_once off;
+        sub_filter_types text/html application/javascript;
+
+        # Inject script to handle localStorage access errors in iframe context
+        sub_filter '</head>' '<script>
+(function() {
+    // localStorage workaround for iframe context
+    if (!window.localStorage) {
+        window.localStorage = {
+            _data: {},
+            setItem: function(id, val) { this._data[id] = String(val); },
+            getItem: function(id) { return this._data.hasOwnProperty(id) ? this._data[id] : null; },
+            removeItem: function(id) { delete this._data[id]; },
+            clear: function() { this._data = {}; },
+            get length() { return Object.keys(this._data).length; },
+            key: function(index) { return Object.keys(this._data)[index] || null; }
+        };
+    }
+
+    // Wrap original localStorage to catch SecurityErrors
+    const originalLocalStorage = window.localStorage;
+    const safeLocalStorage = {
+        setItem: function(key, value) {
+            try {
+                return originalLocalStorage.setItem(key, value);
+            } catch(e) {
+                console.warn("localStorage.setItem blocked in iframe:", e);
+            }
+        },
+        getItem: function(key) {
+            try {
+                return originalLocalStorage.getItem(key);
+            } catch(e) {
+                console.warn("localStorage.getItem blocked in iframe:", e);
+                return null;
+            }
+        },
+        removeItem: function(key) {
+            try {
+                return originalLocalStorage.removeItem(key);
+            } catch(e) {
+                console.warn("localStorage.removeItem blocked in iframe:", e);
+            }
+        },
+        clear: function() {
+            try {
+                return originalLocalStorage.clear();
+            } catch(e) {
+                console.warn("localStorage.clear blocked in iframe:", e);
+            }
+        }
+    };
+
+    // Override localStorage with safe wrapper
+    try {
+        Object.defineProperty(window, "localStorage", {
+            value: safeLocalStorage,
+            writable: false,
+            configurable: false
+        });
+    } catch(e) {
+        console.warn("Could not override localStorage:", e);
+    }
+})();
+</script></head>';
+    }
 }
 
 # Homepage HTTPS with Authentication


### PR DESCRIPTION
## Summary
- Fixed iframe embedding issues for services in Glance dashboard
- Added iframe-friendly headers to nginx configuration for Open-WebUI canary
- Cleaned up Homepage and Glance service configurations
- Replaced non-working iframe tabs with WIP placeholders

## Changes Made

### Nginx Configuration
- Added iframe-friendly headers to Open-WebUI canary location blocks
- Fixed container name references (using proper `co-` prefixed names)
- Added canary domain to HTTP-to-HTTPS redirect
- Implemented localStorage polyfill for Perplexica iframe compatibility

### Glance Dashboard (local config changes)
- Removed WebUI Canary iframe tab that wasn't loading
- Added Open-WebUI Canary (WIP) placeholder with "Open in New Tab" button
- Reorganized tabs for better user experience

### Homepage Dashboard (local config changes)
- Removed redundant services:
  - Authentication Portal
  - Open-WebUI Production
  - Homepage Dashboard (self-reference)
  - Tailscale
  - Watchtower widget
- Kept essential services:
  - Open-WebUI Canary
  - Perplexica Search
  - Nginx Proxy Manager
  - Whatbox services
  - Documentation links

## Testing
- Verified nginx configuration is valid
- Confirmed all services are healthy
- Tested iframe headers are properly set
- Both canary and production Open-WebUI instances remain isolated
