### PR TITLE
Fix: Rename .github/README.md to avoid confusion with main project README

### DIFF
--- a/.github/SECURITY-WORKFLOWS.md
+++ b/.github/SECURITY-WORKFLOWS.md
@@ -1,6 +1,6 @@
 # GitHub Actions Security Workflows
 
-This directory contains comprehensive security workflows for Carian Observatory that enforce domain sanitization, secret detection, and template compliance.
+This document describes the comprehensive security workflows for Carian Observatory that enforce domain sanitization, secret detection, and template compliance.
 
 ## 🔒 Workflow Overview
 


### PR DESCRIPTION
## Summary
- Renamed `.github/README.md` to `.github/SECURITY-WORKFLOWS.md`
- Updated document title to reflect its specific purpose

## Problem Solved
The `.github/README.md` file was causing confusion as some tools displayed it instead of the main project README. This file specifically documents GitHub Actions security workflows, not the main project overview.

## Changes
- File rename: `.github/README.md` → `.github/SECURITY-WORKFLOWS.md`
- Updated document description to clarify its purpose
- Main project README remains the authoritative project documentation

## Test Plan
- Verify main project README displays correctly in repository tools
- Confirm security workflows documentation is still accessible