### PR TITLE
fix(nginx): resolve DNS resolution restart loop with upstream variables

### DIFF
--- a/services/nginx/configs/https.conf.template
+++ b/services/nginx/configs/https.conf.template
@@ -234,7 +234,8 @@ server {
         error_page 401 =302 https://auth.yourdomain.com/?rd=$scheme://$http_host$request_uri;
         
         proxy_set_header Remote-User $user;
-        proxy_pass http://perplexica:3000;
+        set $upstream_perplexica co-perplexica-service:3000;
+        proxy_pass http://$upstream_perplexica;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -264,7 +265,8 @@ server {
         add_header Content-Security-Policy "frame-ancestors 'self' https://glance.yourdomain.com https://*.yourdomain.com;" always;
 
         proxy_set_header Remote-User $user;
-        proxy_pass http://perplexica:3000;
+        set $upstream_perplexica co-perplexica-service:3000;
+        proxy_pass http://$upstream_perplexica;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -318,7 +320,8 @@ server {
         auth_request_set $user $upstream_http_remote_user;
         error_page 401 =302 https://auth.yourdomain.com/?rd=$scheme://$http_host$request_uri;
         
-        proxy_pass http://homepage:3000;
+        set $upstream_homepage co-homepage-service:3000;
+        proxy_pass http://$upstream_homepage;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -349,7 +352,8 @@ server {
         add_header Content-Security-Policy "frame-ancestors 'self' https://glance.yourdomain.com https://*.yourdomain.com;" always;
 
         proxy_set_header Remote-User $user;
-        proxy_pass http://homepage:3000/;
+        set $upstream_homepage co-homepage-service:3000;
+        proxy_pass http://$upstream_homepage/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -517,7 +521,8 @@ server {
     }
     
     location /perplexica/ {
-        proxy_pass http://perplexica:3000/;
+        set $upstream_perplexica co-perplexica-service:3000;
+        proxy_pass http://$upstream_perplexica/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary

Fixes the nginx constant restart loop issue that occurred when nginx started before dependent services. The problem was caused by DNS resolution failures for hardcoded service hostnames in the nginx configuration.

## Root Cause

- Nginx configuration referenced services by compose service names (`perplexica`, `homepage`) instead of actual container names
- DNS resolution happened at nginx startup, causing failures when services weren't ready
- Error: `host not found in upstream 'perplexica' in /etc/nginx/conf.d/default.conf:237`

## Solution

- Replace hardcoded `proxy_pass` URLs with nginx variables that resolve at request time
- Use actual container names (`co-perplexica-service`, `co-homepage-service`)
- DNS resolution now deferred until request time, preventing startup failures

## Changes

- **services/nginx/configs/https.conf.template**:
  - Replace `proxy_pass http://perplexica:3000` with upstream variables
  - Replace `proxy_pass http://homepage:3000` with upstream variables
  - Updated all 5 instances across HTTPS and fallback server blocks

## Testing

- Nginx now starts successfully without restart loops
- Services can start in any order without breaking nginx
- Verified no DNS resolution errors in nginx logs
- All services accessible via their configured domains

## Benefits

- Eliminates nginx restart loops on system startup
- More resilient service startup order
- Future-proofs against similar DNS resolution issues
- Maintains all existing functionality

Fixes the restart issue reported in system logs.